### PR TITLE
Add basic info to the Dockerfile and remove the pacman cache during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ LABEL description="A container including every needed files, packages and depend
 # Enable the multilib repository
 RUN printf "\n[multilib]\nInclude = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf
 
-# Update the container, install the necessary packages and remove pacman cache (to reduce the image size)
+# Update the container, install the necessary packages and remove the pacman cache (to reduce the image size)
 RUN pacman -Syy && pacman -Syu --noconfirm fuse nss at-spi2-core cups gtk3 alsa-utils lib32-libpulse wine && rm -rf /var/cache/pacman/pkg/*
 
 # Download the Ankama Launcher AppImage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-# Basic info
-MAINTAINER Robin Candau <robincandau@protonmail.com>
-LABEL description="A container including every needed files, packages and dependencies to run the Ankama launcher and the related games (meant to be used with distrobox)."
-
-# Build the container from the latest Arch Linux base image
+# Build the container from the Arch Linux base image
 FROM archlinux:base
+
+# Basic info
+LABEL maintainer="Robin Candau <robincandau@protonmail.com>"
+LABEL description="A container including every needed files, packages and dependencies to run the Ankama launcher and the related games (meant to be used with distrobox)."
 
 # Enable the multilib repository
 RUN printf "\n[multilib]\nInclude = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+# Basic info
+MAINTAINER Robin Candau <robincandau@protonmail.com>
+LABEL description="A container including every needed files, packages and dependencies to run the Ankama launcher and the related games (meant to be used with distrobox)."
+
 # Build the container from the latest Arch Linux base image
 FROM archlinux:base
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ FROM archlinux:base
 # Enable the multilib repository
 RUN printf "\n[multilib]\nInclude = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf
 
-# Update the container and install the necessary packages
-RUN pacman -Syy && pacman -Syu --noconfirm fuse nss at-spi2-core cups gtk3 alsa-utils lib32-libpulse wine
+# Update the container, install the necessary packages and remove pacman cache (to reduce the image size)
+RUN pacman -Syy && pacman -Syu --noconfirm fuse nss at-spi2-core cups gtk3 alsa-utils lib32-libpulse wine && rm -rf /var/cache/pacman/pkg/*
 
 # Download the Ankama Launcher AppImage
 ADD https://download.ankama.com/launcher/full/linux /opt/Ankama/Ankama-Launcher-x86_64.AppImage

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ LABEL description="A container including every needed files, packages and depend
 RUN printf "\n[multilib]\nInclude = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf
 
 # Update the container, install the necessary packages and remove the pacman cache (to reduce the image size)
-RUN pacman -Syy && pacman -Syu --noconfirm fuse nss at-spi2-core cups gtk3 alsa-utils lib32-libpulse wine && rm -rf /var/cache/pacman/pkg/*
+RUN pacman -Syy && pacman -Syu --noconfirm fuse nss at-spi2-core cups gtk3 alsa-utils lib32-libpulse wine && rm -f /var/cache/pacman/pkg/*
 
 # Download the Ankama Launcher AppImage
 ADD https://download.ankama.com/launcher/full/linux /opt/Ankama/Ankama-Launcher-x86_64.AppImage


### PR DESCRIPTION
This PR aims to add basic info to the Dockerfile (Maintainer, Description) as well as removing the `pacman` cache after installing packages in order to reduce the image size.