### PR TITLE
Use a precise tag for the Arch base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the container from the Arch Linux base image
-FROM archlinux:base
+FROM archlinux:base-20230723.0.166908
 
 # Basic info
 LABEL maintainer="Robin Candau <robincandau@protonmail.com>"


### PR DESCRIPTION
This PR aims to use a precise tag for the Arch base image the Dockerfile.

Indeed, using the `base` tag on its own is basically the same as using the `latest` tag.
Regarding best practices and for the future rebuilds of the image, using a precise tag will allow a finer control over the image.