### PR TITLE
Remove Waven from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## Description
 
-A container including every needed files, packages and dependencies to run the [Ankama launcher](https://www.ankama.com/en/launcher) and the related games (Dofus, Dofus-Retro, Wakfu, Waven).  
+A container including every needed files, packages and dependencies to run the [Ankama launcher](https://www.ankama.com/en/launcher) and the related games (Dofus, Dofus-Retro, Wakfu).  
 It is meant to be used with [distrobox](https://github.com/89luca89/distrobox), the container won't be able to launch the Ankama launcher with plain old Docker/Podman *as is*.
 
 *"Why would I use this instead of simply running the AppImage directly on my system?"*  


### PR DESCRIPTION
Waven isn't included in the Ankama Launcher by default yet.