### PR TITLE
Remove the Terminal statement for the rootless and SteamOS desktop files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,14 +8,14 @@ all:
 
 install:
 	install -Dm 755 "src/script/${pkgname}.sh" "${DESTDIR}${PREFIX}/bin/${pkgname}"
-	install -Dm 644 "res/icon/${pkgname}.svg" "${DESTDIR}/usr/share/icons/${pkgname}/${pkgname}.svg"
 	install -Dm 644 "res/desktop/${pkgname}.desktop" "${DESTDIR}${PREFIX}/share/applications/${pkgname}.desktop"
+	install -Dm 644 "res/icon/${pkgname}.svg" "${DESTDIR}/usr/share/icons/${pkgname}/${pkgname}.svg"
 	install -Dm 644 README.md "${DESTDIR}${PREFIX}/share/doc/${pkgname}/README.md"
 
 install-rootless:
 	install -Dm 755 "src/script/${pkgname}_rootless.sh" "${DESTDIR}${PREFIX}/bin/${pkgname}"
+	install -Dm 644 "res/desktop/${pkgname}_rootless.desktop" "${DESTDIR}${PREFIX}/share/applications/${pkgname}.desktop"
 	install -Dm 644 "res/icon/${pkgname}.svg" "${DESTDIR}/usr/share/icons/${pkgname}/${pkgname}.svg"
-	install -Dm 644 "res/desktop/${pkgname}.desktop" "${DESTDIR}${PREFIX}/share/applications/${pkgname}.desktop"
 	install -Dm 644 README.md "${DESTDIR}${PREFIX}/share/doc/${pkgname}/README.md"
 
 uninstall:

--- a/res/desktop/ankama-launcher-container_rootless.desktop
+++ b/res/desktop/ankama-launcher-container_rootless.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Type=Application
+Name=Ankama Launcher Container
+Icon=/usr/share/icons/ankama-launcher-container/ankama-launcher-container.svg
+Exec=ankama-launcher-container

--- a/res/desktop/ankama-launcher-container_steamos.desktop
+++ b/res/desktop/ankama-launcher-container_steamos.desktop
@@ -1,6 +1,5 @@
 [Desktop Entry]
 Type=Application
-Terminal=true
 Name=Ankama Launcher Container
 Icon=/home/deck/.local/share/icons/ankama-launcher-container/ankama-launcher-container.svg
 Exec=bash -c 'export PATH="$HOME/.local/bin:$HOME/.local/podman/bin:$PATH" && ankama-launcher-container'


### PR DESCRIPTION
This PR aims to remove the `Terminal` statement for the rootless and SteamOS desktop files as running the application as a terminal app isn't required with a rootless environment.