### PR TITLE
Add more permissive permissions to the /opt/Ankama folder to prevent failing updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN pacman -Syy && pacman -Syu --noconfirm fuse nss at-spi2-core cups gtk3 alsa-
 
 # Download the Ankama Launcher AppImage
 ADD https://download.ankama.com/launcher/full/linux /opt/Ankama/Ankama-Launcher-x86_64.AppImage
-RUN chmod 755 /opt/Ankama/Ankama-Launcher-x86_64.AppImage
+RUN chmod -R 777 /opt/Ankama/
 
 # Create a custom binary to launch the Ankama Launcher
 RUN mkdir -p /usr/local/bin && printf "#!/bin/bash\n\n/opt/Ankama/Ankama-Launcher-x86_64.AppImage" > /usr/local/bin/ankama-launcher && chmod 755 /usr/local/bin/ankama-launcher


### PR DESCRIPTION
The Ankama Launcher apparently needs more permissive permissions to perform update as of now. Performing update with a classic `755` perms resulted in:
> Error: EACCES: permission denied, unlink '/opt/Ankama/Ankama-Launcher-x86_64.AppImage'

While `777` perms are usually to avoid, settings this kind of permissives permissions on the `/opt/Ankama` directory within the container fixes the issue and shouldn't cause any security concern (since this directory is located within the container itself and only contains the appimage).