### PR TITLE
Fix pacman command to clean cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ LABEL description="A container including every needed files, packages and depend
 RUN printf "\n[multilib]\nInclude = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf
 
 # Update the container, install the necessary packages and remove the pacman cache (to reduce the image size)
-RUN pacman -Syyu --noconfirm fuse nss at-spi2-core cups gtk3 alsa-utils lib32-libpulse wine && pacman -Scc --noconfirm
+RUN pacman -Syyu --noconfirm fuse nss at-spi2-core cups gtk3 alsa-utils lib32-libpulse wine && yes | pacman -Scc
 
 # Download the Ankama Launcher AppImage
 ADD https://download.ankama.com/launcher/full/linux /opt/Ankama/Ankama-Launcher-x86_64.AppImage


### PR DESCRIPTION
The default answer to cleaning the cached packages is 'N' (no), so using --noconfirm will actually **not** clean the packages. Use 'yes | cmd' instead.