### PR TITLE
Correct download link for the Ankama Launcher AppImage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,7 @@ RUN printf "\n[multilib]\nInclude = /etc/pacman.d/mirrorlist" >> /etc/pacman.con
 RUN pacman -Syyu --noconfirm fuse nss at-spi2-core cups gtk3 alsa-utils lib32-libpulse wine && yes | pacman -Scc
 
 # Download the Ankama Launcher AppImage
-ADD https://download.ankama.com/launcher/full/linux /opt/Ankama/Ankama-Launcher-x86_64.AppImage
-RUN chmod -R 777 /opt/Ankama/
+RUN mkdir /opt/Ankama/ && curl 'https://launcher.cdn.ankama.com/installers/production/Ankama%20Launcher-Setup-x86_64.AppImage' -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:121.0) Gecko/20100101 Firefox/121.0' -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8' -H 'Accept-Language: fr-FR,en-US;q=0.7,en;q=0.3' -H 'Accept-Encoding: gzip, deflate, br' -H 'Referer: https://www.ankama.com/' -H 'Connection: keep-alive' -H 'Cookie: cf_clearance=_bsXnjXvzk3PSekIekMQpT5suy0EgvfyJOWeB3TA5vs-1703325144-0-2-764d1ac1.535c371.214c4521-0.2.1703325144; GUID=7F9222204488F906E9D6712F6EBF068C01D2C57959FA94E390980B1F7B8A3DA1123B326910E9C2D6EB2274FE1071D436; SID=162ed35e4b7f781615e41ad42cd4d0a6; ADWRF=47401555' -H 'Upgrade-Insecure-Requests: 1' -H 'Sec-Fetch-Dest: document' -H 'Sec-Fetch-Mode: navigate' -H 'Sec-Fetch-Site: same-site' -H 'Sec-Fetch-User: ?1' -o /opt/Ankama/Ankama-Launcher-x86_64.AppImage && chmod -R 777 /opt/Ankama/
 
 # Create a custom binary to launch the Ankama Launcher
 RUN mkdir -p /usr/local/bin && printf "#!/bin/bash\n\n/opt/Ankama/Ankama-Launcher-x86_64.AppImage" > /usr/local/bin/ankama-launcher && chmod 755 /usr/local/bin/ankama-launcher


### PR DESCRIPTION
It seems like Ankama blocked downloading the AppImage without specific user-agent, causing the ADD statement to fail downloading it. This commit aims to replace the ADD statement by a curl command including the required parameter to download the AppImage (taken from Firefox's Dev Panel/Network Tab)