### PR TITLE
Rebuild to address the xz backdoor/security issue + switch to Arch's DockerHub repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the container from the Arch Linux base image
-FROM archlinux:base-20240101.0.204074
+FROM archlinux/archlinux:base-20240330.0.225642
 
 # Basic info
 LABEL maintainer="Robin Candau <robincandau@protonmail.com>"


### PR DESCRIPTION
About the xz matter:
https://www.openwall.com/lists/oss-security/2024/03/29/4
https://archlinux.org/news/the-xz-package-has-been-backdoored/ 
https://security.archlinux.org/ASA-202403-1

About the switch to Arch's DockerHub repository:
Arch Linux container images are built daily on Arch's DockerHub repository (compared to being built weekly on the official DockerHub library). Switching to a daily updated source allows to act faster on such eventual issue (as, for instance, the "latest" Arch image on the official DockerHub library currently is 14 days old, and do not contain the fix yet).