### PR TITLE
Install xdg-utils and firefox in the container to fix the initial login to Ankama services

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ LABEL description="A container including every needed files, packages and depend
 RUN printf "\n[multilib]\nInclude = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf
 
 # Update the container, install the necessary packages and remove the pacman cache (to reduce the image size)
-RUN pacman -Syyu --noconfirm fuse nss at-spi2-core cups gtk3 alsa-utils lib32-libpulse wine && yes | pacman -Scc
+RUN pacman -Syyu --noconfirm fuse nss at-spi2-core cups gtk3 alsa-utils lib32-libpulse wine firefox xdg-utils && yes | pacman -Scc
 
 # Download the Ankama Launcher AppImage
 RUN mkdir /opt/Ankama/ && curl -L 'https://download.ankama.com/launcher-dofus/full/linux' -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:121.0) Gecko/20100101 Firefox/121.0' -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8' -H 'Accept-Language: fr-FR,en-US;q=0.7,en;q=0.3' -H 'Accept-Encoding: gzip, deflate, br' -H 'Referer: https://www.ankama.com/' -H 'Connection: keep-alive' -H 'Cookie: cf_clearance=_bsXnjXvzk3PSekIekMQpT5suy0EgvfyJOWeB3TA5vs-1703325144-0-2-764d1ac1.535c371.214c4521-0.2.1703325144; GUID=7F9222204488F906E9D6712F6EBF068C01D2C57959FA94E390980B1F7B8A3DA1123B326910E9C2D6EB2274FE1071D436; SID=162ed35e4b7f781615e41ad42cd4d0a6; ADWRF=47401555' -H 'Upgrade-Insecure-Requests: 1' -H 'Sec-Fetch-Dest: document' -H 'Sec-Fetch-Mode: navigate' -H 'Sec-Fetch-Site: same-site' -H 'Sec-Fetch-User: ?1' -o /opt/Ankama/Ankama-Launcher-x86_64.AppImage && chmod -R 777 /opt/Ankama/


### PR DESCRIPTION
The Ankama Launcher now expects to be able to open a web browser to allow you to log in to Ankama Services (it doesn't allow you to login directly from the launcher anymore for some reason...).

Distrobox supposedly [allow to open links from the host's web browser](https://github.com/89luca89/distrobox/commit/e15cec7e3264878075ad8ee6161a06f7a53b6749#diff-9020f2495b4d9502f4b28c23de195d9bb5b78f003378f25416bc016cc4996865R895) but it doesn't seem to work with every setup (at least it doesn't on mine), eventually preventing people to login to Ankama services and play games.

As a workaround, we'll now install a web browser within the container (firefox) and open links directly through it, instead of relying on the host machine's web browser (which will eventually fail depending on the host's setup). This might not be the most elegant solution, but at least it's guaranteed to work with every setup.