### PR TITLE
Update base image to base-20250118.0.299213

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the container from the Arch Linux base image
-FROM archlinux/archlinux:base-20250105.0.295189
+FROM archlinux/archlinux:base-20250118.0.299213
 
 # Basic info
 LABEL maintainer="Robin Candau <robincandau@protonmail.com>"


### PR DESCRIPTION
Addresses the [rsync vulnerability fixes](https://archlinux.org/news/critical-rsync-security-release-340/) (which is pulled by distrobox).